### PR TITLE
Add support for Jansi library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ repositories {
 dependencies {
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.5.0'
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.5.0'
+    compile group: 'org.fusesource.jansi', name: 'jansi', version: '2.0.1'
 }
 
 test {

--- a/src/main/java/fitr/Fitr.java
+++ b/src/main/java/fitr/Fitr.java
@@ -9,6 +9,7 @@ import fitr.tip.TipManager;
 import fitr.ui.Ui;
 import fitr.user.User;
 import fitr.parser.Parser;
+import org.fusesource.jansi.AnsiConsole;
 
 import java.io.IOException;
 
@@ -51,6 +52,8 @@ public class Fitr {
     }
 
     public static void main(String[] args) {
+        AnsiConsole.systemInstall();
         new Fitr().run();
+        AnsiConsole.systemUninstall();
     }
 }


### PR DESCRIPTION
Thanks to bug reports, ANSI colour codes were not appearing properly on Windows command prompt. A library is now used to handle this, and now it should work as expected.